### PR TITLE
chore: changed cname for money timer rebrand

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-gratitudecalculator.anthonyisensee.com
+moneytimer.anthonyisensee.com


### PR DESCRIPTION
Change to CNAME file to host site on github pages at a different URL. 

Outside of GitHub:

- Added DNS records for 301 permanent redirect from https://gratitudecalculator.anthonyisensee.com to https://moneytimer.anthonyisensee.com 
- Added DNS CNAME record 

Will shortly be changing repository name.