### PR TITLE
fix: null coalesce stored time periods

### DIFF
--- a/js/TimeTracker.js
+++ b/js/TimeTracker.js
@@ -12,7 +12,7 @@ export class TimeTracker {
         this._storageInterface = new LocalStorageInterface();
 
         // Locally stored time periods lose their class. Thus, we must recast them to TimePeriod objects.
-        const stored_data = this._storageInterface.get('time_periods');
+        const stored_data = this._storageInterface.get('time_periods') ?? [];
         const stored_time_periods = [];
         stored_data.forEach(stored_object => {
             stored_time_periods.push(new TimePeriod(stored_object._startTime, stored_object._endTime, stored_object._totalTime));


### PR DESCRIPTION
Implement [javascript nullish coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) for time periods loaded out of local storage. Fixes a bug that causes js errors on first time load when there are no time periods to iterate over, causing all js execution to stop.